### PR TITLE
Fix gyp binding target 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,2 @@
-grammar_test
+corpus
 build
-script
-

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "ts_language_swift_binding",
+      "target_name": "tree_sitter_swift_binding",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "src"


### PR DESCRIPTION
af1c503845947bb85bcf2be72dcaa4ede8b0ce66 changed the name of the binding we are loading, but didn't update the bindings file's target name. This fixes that. 